### PR TITLE
Mode to send classifierReports to management cluster

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -38,3 +38,4 @@ spec:
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
         - "--v=5"
+        - "--run-mode=noreport"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,6 +38,8 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - --v=5
+        - --run-mode=noreport
         image: controller:latest
         name: manager
         securityContext:

--- a/controllers/classifier_controller_test.go
+++ b/controllers/classifier_controller_test.go
@@ -40,7 +40,8 @@ var _ = Describe("Controllers: node controller", func() {
 
 	BeforeEach(func() {
 		watcherCtx, cancel = context.WithCancel(context.Background())
-		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client, nil, 10)
+		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client,
+			randomString(), randomString(), nil, 10, false)
 	})
 
 	AfterEach(func() {

--- a/controllers/node_controller_test.go
+++ b/controllers/node_controller_test.go
@@ -84,7 +84,8 @@ var _ = Describe("Controllers: node controller", func() {
 		currentNode.Status = node.Status
 		Expect(testEnv.Status().Update(watcherCtx, &currentNode)).To(Succeed())
 
-		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client, nil, 10)
+		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client,
+			randomString(), randomString(), nil, 10, false)
 
 		reconciler := &controllers.NodeReconciler{
 			Client: testEnv.Client,

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,14 @@ module github.com/projectsveltos/classifier-agent
 go 1.19
 
 require (
+	emperror.dev/errors v0.8.1
 	github.com/Masterminds/semver v1.5.0
 	github.com/TwinProduction/go-color v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.1
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.2.2-0.20221117231616-d7ca41ed41e0
+	github.com/projectsveltos/libsveltos v0.2.2-0.20221123222816-cabec7f620c4
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/text v0.3.7
 	k8s.io/api v0.25.3
@@ -66,6 +67,8 @@ require (
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/spf13/cobra v1.5.0 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/net v0.0.0-20220906165146-f3363e06e74c // indirect
 	golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+emperror.dev/errors v0.8.1 h1:UavXZ5cSX/4u9iyvH6aDcuGkVjeexUGJ7Ij7G4VfQT0=
+emperror.dev/errors v0.8.1/go.mod h1:YcRvLPh626Ubn2xqtoprejnA5nFha+TJ+2vew48kWuE=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
@@ -435,8 +437,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
-github.com/projectsveltos/libsveltos v0.2.2-0.20221117231616-d7ca41ed41e0 h1:HUtKgZREEdoos5qn/R8NK+e6eCcVdqS6krj4z+h84Ck=
-github.com/projectsveltos/libsveltos v0.2.2-0.20221117231616-d7ca41ed41e0/go.mod h1:k9Jjz/3Rjudo/c9Lq/AUSYyUVrKkvcv68ty45Q5SG58=
+github.com/projectsveltos/libsveltos v0.2.2-0.20221123222816-cabec7f620c4 h1:fhaonokaiMAN1lf2Q3lehji89altyVY5hC5uh7i5o90=
+github.com/projectsveltos/libsveltos v0.2.2-0.20221123222816-cabec7f620c4/go.mod h1:k9Jjz/3Rjudo/c9Lq/AUSYyUVrKkvcv68ty45Q5SG58=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -273,6 +273,7 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --v=5
+        - --run-mode=noreport
         command:
         - /manager
         image: gianlucam76/classifier-agent-manager-amd64:v0.2.1

--- a/pkg/classification/evaluation.go
+++ b/pkg/classification/evaluation.go
@@ -19,17 +19,24 @@ package classification
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
+	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/projectsveltos/classifier-agent/pkg/utils"
 	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
@@ -109,6 +116,14 @@ func (m *manager) evaluateClassifierInstance(ctx context.Context, classifierName
 	if err != nil {
 		logger.Error(err, "failed to create/update ClassifierReport")
 		return err
+	}
+
+	if m.sendReport {
+		err = m.sendClassifierReport(ctx, classifier)
+		if err != nil {
+			logger.Error(err, "failed to send ClassifierReport")
+			return err
+		}
 	}
 
 	return nil
@@ -289,6 +304,120 @@ func (m *manager) getClassifierReport(classifierName string, isMatch bool) *libs
 			Match:          isMatch,
 		},
 	}
+}
+
+// getManamegentClusterClient gets the Secret containing the Kubeconfig to access
+// management cluster and return magamenet cluster client.
+func (m *manager) getManamegentClusterClient(ctx context.Context, logger logr.Logger,
+) (client.Client, error) {
+
+	kubeconfigContent, err := m.getKubeconfig(ctx)
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get management cluster kubeconfig: %v", err))
+		return nil, err
+	}
+
+	kubeconfigFile, err := os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get store kubeconfig: %v", err))
+		return nil, err
+	}
+	defer os.Remove(kubeconfigFile.Name())
+
+	_, err = kubeconfigFile.Write(kubeconfigContent)
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get store kubeconfig: %v", err))
+		return nil, err
+	}
+
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigFile.Name())
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get management cluster config: %v", err))
+		return nil, err
+	}
+
+	s := runtime.NewScheme()
+	err = libsveltosv1alpha1.AddToScheme(s)
+	if err != nil {
+		return nil, err
+	}
+
+	agentClient, err := client.New(restConfig, client.Options{Scheme: s})
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get management cluster client: %v", err))
+		return nil, err
+	}
+
+	return agentClient, nil
+}
+
+// sendClassifierReport sends classifierReport to management cluster
+func (m *manager) sendClassifierReport(ctx context.Context, classifier *libsveltosv1alpha1.Classifier) error {
+	logger := m.log.WithValues("classifier", classifier.Name)
+
+	classifierReport := &libsveltosv1alpha1.ClassifierReport{}
+	err := m.Get(ctx,
+		types.NamespacedName{Namespace: utils.ReportNamespace, Name: classifier.Name}, classifierReport)
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get classifier: %v", err))
+		return err
+	}
+
+	agentClient, err := m.getManamegentClusterClient(ctx, logger)
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get management cluster client: %v", err))
+		return err
+	}
+
+	logger.V(logs.LogDebug).Info("send classifierReport to management cluster")
+
+	classifierReportName := libsveltosv1alpha1.GetClassifierReportName(classifier.Name, m.clusterName)
+	classifierReportNamespace := m.clusterNamespace
+
+	currentClassifierReport := &libsveltosv1alpha1.ClassifierReport{}
+
+	err = agentClient.Get(ctx,
+		types.NamespacedName{Namespace: classifierReportNamespace, Name: classifierReportName},
+		currentClassifierReport)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			currentClassifierReport.Namespace = classifierReportNamespace
+			currentClassifierReport.Name = classifierReportName
+			currentClassifierReport.Spec = classifierReport.Spec
+			currentClassifierReport.Spec.ClusterNamespace = m.clusterNamespace
+			currentClassifierReport.Spec.ClusterName = m.clusterName
+			currentClassifierReport.Labels = map[string]string{
+				libsveltosv1alpha1.ClassifierReportClusterLabel: libsveltosv1alpha1.GetClusterInfo(m.clusterNamespace, m.clusterName),
+			}
+			return agentClient.Create(ctx, currentClassifierReport)
+		}
+		return err
+	}
+
+	currentClassifierReport.Spec.Match = classifierReport.Spec.Match
+	currentClassifierReport.Labels = map[string]string{
+		libsveltosv1alpha1.ClassifierReportClusterLabel: libsveltosv1alpha1.GetClusterInfo(m.clusterNamespace, m.clusterName),
+	}
+	return agentClient.Update(ctx, currentClassifierReport)
+}
+
+func (m *manager) getKubeconfig(ctx context.Context) ([]byte, error) {
+	secret := &corev1.Secret{}
+	key := client.ObjectKey{
+		Namespace: libsveltosv1alpha1.ClassifierSecretNamespace,
+		Name:      libsveltosv1alpha1.ClassifierSecretName,
+	}
+
+	if err := m.Get(ctx, key, secret); err != nil {
+		return nil, errors.Wrap(err,
+			fmt.Sprintf("Failed to get secret %s", key))
+	}
+
+	for _, contents := range secret.Data {
+		return contents, nil
+	}
+
+	return nil, nil
 }
 
 // createClassifierReport creates ClassifierReport or updates it if already exists.

--- a/pkg/classification/export_test.go
+++ b/pkg/classification/export_test.go
@@ -43,6 +43,8 @@ var (
 	GetInstalledResources      = (*manager).getInstalledResources
 	StartWatcher               = (*manager).startWatcher
 	UpdateWatchers             = (*manager).updateWatchers
+	GetManamegentClusterClient = (*manager).getManamegentClusterClient
+	SendClassifierReport       = (*manager).sendClassifierReport
 )
 
 func Reset() {

--- a/pkg/classification/manager.go
+++ b/pkg/classification/manager.go
@@ -51,6 +51,10 @@ type manager struct {
 	client.Client
 	config *rest.Config
 
+	sendReport       bool
+	clusterNamespace string
+	clusterName      string
+
 	watchMu *sync.Mutex
 	// rebuildResourceToWatch indicates (value different from zero) that list
 	// of resources to watch needs to be rebuilt
@@ -79,7 +83,7 @@ type manager struct {
 
 // InitializeManager initializes a manager implementing the ClassifierInterface
 func InitializeManager(ctx context.Context, l logr.Logger, config *rest.Config, c client.Client,
-	react ReactToNotification, intervalInSecond uint) {
+	clusterNamespace, clusterName string, react ReactToNotification, intervalInSecond uint, sendReport bool) {
 
 	if managerInstance == nil {
 		getManagerLock.Lock()
@@ -100,6 +104,9 @@ func InitializeManager(ctx context.Context, l logr.Logger, config *rest.Config, 
 			managerInstance.watchers = make(map[schema.GroupVersionKind]context.CancelFunc)
 
 			managerInstance.react = react
+			managerInstance.sendReport = sendReport
+			managerInstance.clusterNamespace = clusterNamespace
+			managerInstance.clusterName = clusterName
 
 			go managerInstance.evaluateClassifiers(ctx)
 			go managerInstance.buildResourceToWatch(ctx)

--- a/pkg/classification/watchers_test.go
+++ b/pkg/classification/watchers_test.go
@@ -102,7 +102,8 @@ var _ = Describe("Manager: watchers", func() {
 				client.ObjectKey{Name: classifier.Name}, currentClassifier)
 		}, timeout, pollingInterval).Should(BeNil())
 
-		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client, nil, 10)
+		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client,
+			randomString(), randomString(), nil, 10, false)
 		manager := classification.GetManager()
 		gvks, err := classification.BuildList(manager, context.TODO())
 		Expect(err).To(BeNil())
@@ -119,7 +120,8 @@ var _ = Describe("Manager: watchers", func() {
 	})
 
 	It("buildSortedList creates a sorted list", func() {
-		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client, nil, 10)
+		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client,
+			randomString(), randomString(), nil, 10, false)
 		manager := classification.GetManager()
 
 		gvk1 := schema.GroupVersionKind{Group: pods.Group, Version: pods.Version, Kind: pods.Kind}
@@ -134,7 +136,8 @@ var _ = Describe("Manager: watchers", func() {
 	})
 
 	It("gvkInstalled returns true if resource is installed, false otherwise", func() {
-		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client, nil, 10)
+		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client,
+			randomString(), randomString(), nil, 10, false)
 		manager := classification.GetManager()
 
 		gvk1 := schema.GroupVersionKind{Group: pods.Group, Version: pods.Version, Kind: pods.Kind}
@@ -155,7 +158,8 @@ var _ = Describe("Manager: watchers", func() {
 	})
 
 	It("getInstalledResources returns list of installed api-resources", func() {
-		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client, nil, 10)
+		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client,
+			randomString(), randomString(), nil, 10, false)
 		manager := classification.GetManager()
 
 		resources, err := classification.GetInstalledResources(manager)
@@ -170,7 +174,8 @@ var _ = Describe("Manager: watchers", func() {
 	})
 
 	It("startWatcher starts a watcher when resource is installed", func() {
-		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client, nil, 10)
+		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client,
+			randomString(), randomString(), nil, 10, false)
 		manager := classification.GetManager()
 
 		gvk := &schema.GroupVersionKind{Group: classifiers.Group, Version: classifiers.Version, Kind: classifiers.Kind}
@@ -185,7 +190,8 @@ var _ = Describe("Manager: watchers", func() {
 	})
 
 	It("updateWatchers starts new watchers", func() {
-		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client, nil, 10)
+		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client,
+			randomString(), randomString(), nil, 10, false)
 		manager := classification.GetManager()
 
 		gvk := schema.GroupVersionKind{Group: pods.Group, Version: pods.Version, Kind: pods.Kind}
@@ -201,7 +207,8 @@ var _ = Describe("Manager: watchers", func() {
 	})
 
 	It("updateWatchers stores resources to watch which are not installed yet", func() {
-		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client, nil, 10)
+		classification.InitializeManager(watcherCtx, klogr.New(), testEnv.Config, testEnv.Client,
+			randomString(), randomString(), nil, 10, false)
 		manager := classification.GetManager()
 
 		gvk1 := schema.GroupVersionKind{Group: pods.Group, Version: pods.Version, Kind: pods.Kind}


### PR DESCRIPTION
Classifier agent can be started to send ClassifierReports to management cluster.
In this case it expects a Secret to be present in the projectsveltos namespace. And it expects this Secret to contain a Kubeconfig to access the management cluster.